### PR TITLE
chore(ci): remove Node 16 from CI matrix (end of support)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [17.x, 18.x]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
## Description

chore(ci): remove Node 16 from CI matrix (end of support)